### PR TITLE
Add bootloader name tag

### DIFF
--- a/src/boot_loader_name.rs
+++ b/src/boot_loader_name.rs
@@ -1,0 +1,14 @@
+
+#[derive(Debug)]
+#[repr(packed)] // repr(C) would add unwanted padding before first_section
+pub struct BootLoaderNameTag {
+    typ: u32,
+    size: u32,
+    string: u8,
+}
+
+impl BootLoaderNameTag {
+    pub fn name(&self) -> &str {
+        unsafe { ::core::str::from_utf8_unchecked(::core::slice::from_raw_parts((&self.string) as *const u8, self.size as usize - 8)) }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+pub use boot_loader_name::BootLoaderNameTag;
 pub use elf_sections::{ElfSectionsTag, ElfSection, ElfSectionIter, ElfSectionType, ElfSectionFlags};
 pub use elf_sections::{ELF_SECTION_WRITABLE, ELF_SECTION_ALLOCATED, ELF_SECTION_EXECUTABLE};
 pub use memory_map::{MemoryMapTag, MemoryArea, MemoryAreaIter};
@@ -7,6 +8,7 @@ pub use memory_map::{MemoryMapTag, MemoryArea, MemoryAreaIter};
 #[macro_use]
 extern crate bitflags;
 
+mod boot_loader_name;
 mod elf_sections;
 mod memory_map;
 
@@ -38,6 +40,10 @@ impl BootInformation {
 
     pub fn memory_map_tag(&self) -> Option<&'static MemoryMapTag> {
         self.get_tag(6).map(|tag| unsafe{&*(tag as *const Tag as *const MemoryMapTag)})
+    }
+
+    pub fn boot_loader_name_tag(&self) -> Option<&'static BootLoaderNameTag> {
+        self.get_tag(2).map(|tag| unsafe{&*(tag as *const Tag as *const BootLoaderNameTag)})
     }
 
     fn has_valid_end_tag(&self) -> bool {


### PR DESCRIPTION
This was low-hanging fruit, since the tag has a simple structure and the payload is specified to be valid UTF-8.