### PR TITLE
Added ModuleIter, .gitignore change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+*.swp

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,0 +1,30 @@
+#[repr(C)]
+pub struct Tag {
+    pub typ: u32,
+    pub size: u32,
+    // tag specific fields
+}
+
+pub struct TagIter {
+    pub current: *const Tag,
+}
+
+impl Iterator for TagIter {
+    type Item = &'static Tag;
+
+    fn next(&mut self) -> Option<&'static Tag> {
+        match unsafe{&*self.current} {
+            &Tag{typ:0, size:8} => None, // end tag
+            tag => {
+                // go to next tag
+                let mut tag_addr = self.current as usize;
+                tag_addr += tag.size as usize;
+                tag_addr = ((tag_addr-1) & !0x7) + 0x8; //align at 8 byte
+                self.current = tag_addr as *const _;
+
+                Some(tag)
+            },
+        }
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ pub use boot_loader_name::BootLoaderNameTag;
 pub use elf_sections::{ElfSectionsTag, ElfSection, ElfSectionIter, ElfSectionType, ElfSectionFlags};
 pub use elf_sections::{ELF_SECTION_WRITABLE, ELF_SECTION_ALLOCATED, ELF_SECTION_EXECUTABLE};
 pub use memory_map::{MemoryMapTag, MemoryArea, MemoryAreaIter};
-pub use module::{ModuleTag};
+pub use module::{ModuleTag, ModuleIter};
 
 #[macro_use]
 extern crate bitflags;
@@ -44,8 +44,8 @@ impl BootInformation {
         self.get_tag(6).map(|tag| unsafe{&*(tag as *const Tag as *const MemoryMapTag)})
     }
 
-    pub fn module_tag(&self) -> Option<&'static ModuleTag> {
-        self.get_tag(3).map(|tag| unsafe{&*(tag as *const Tag as *const ModuleTag)})
+    pub fn module_tags(&self) -> ModuleIter {
+        ModuleIter::new(self.tags())
     }
 
     pub fn boot_loader_name_tag(&self) -> Option<&'static BootLoaderNameTag> {
@@ -72,13 +72,13 @@ impl BootInformation {
 }
 
 #[repr(C)]
-struct Tag {
+pub struct Tag {
     typ: u32,
     size: u32,
     // tag specific fields
 }
 
-struct TagIter {
+pub struct TagIter {
     current: *const Tag,
 }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,4 +1,4 @@
-use {Tag, TagIter};
+use header::{Tag, TagIter};
 
 #[repr(packed)]
 #[derive(Debug)]
@@ -33,13 +33,7 @@ impl ModuleTag {
 }
 
 pub struct ModuleIter {
-    iter: TagIter,
-}
-
-impl ModuleIter {
-    pub fn new(iter: TagIter) -> ModuleIter {
-        ModuleIter{ iter: iter }
-    }
+    pub iter: TagIter,
 }
 
 impl Iterator for ModuleIter {

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,3 +1,5 @@
+use {Tag, TagIter};
+
 #[repr(packed)]
 #[derive(Debug)]
 pub struct ModuleTag {
@@ -27,5 +29,24 @@ impl ModuleTag {
 
     pub fn end_address(&self) -> u32 {
         self.mod_end
+    }
+}
+
+pub struct ModuleIter {
+    iter: TagIter,
+}
+
+impl ModuleIter {
+    pub fn new(iter: TagIter) -> ModuleIter {
+        ModuleIter{ iter: iter }
+    }
+}
+
+impl Iterator for ModuleIter {
+    type Item = &'static ModuleTag;
+
+    fn next(&mut self) -> Option<&'static ModuleTag> {
+        self.iter.find(|x| x.typ == 3)
+            .map(|tag| unsafe{&*(tag as *const Tag as *const ModuleTag)})
     }
 }


### PR DESCRIPTION
Why I was originally wary about creating ModuleIter is because I
have to make Tag and TagIter public so that it can work. I can
change this (by practically rewriting TagIter in ModuleIter), but
I think that this works fine (issue/comment if you feel otherwise).

I also made a very small change to .gitignore so that I would not
accidentally commit my .swp files.