### PR TITLE
Make StringTable public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 use header::{Tag, TagIter};
 pub use boot_loader_name::BootLoaderNameTag;
-pub use elf_sections::{ElfSectionsTag, ElfSection, ElfSectionIter, ElfSectionType, ElfSectionFlags};
+pub use elf_sections::{ElfSectionsTag, ElfSection, ElfSectionIter, ElfSectionType, ElfSectionFlags, StringTable};
 pub use elf_sections::{ELF_SECTION_WRITABLE, ELF_SECTION_ALLOCATED, ELF_SECTION_EXECUTABLE};
 pub use memory_map::{MemoryMapTag, MemoryArea, MemoryAreaIter};
 pub use module::{ModuleTag, ModuleIter};


### PR DESCRIPTION
I missed this when pushing the commit, StringTable should be
pub so that the desired functionality of "get your own String
Table and change the address" can work.

I know that this changes the public interface, sorry for opening
it so soon after the release.