### PR TITLE
Add the command line tag

### DIFF
--- a/src/command_line.rs
+++ b/src/command_line.rs
@@ -1,0 +1,19 @@
+
+#[derive(Debug)]
+#[repr(packed)] // repr(C) would add unwanted padding before first_section
+pub struct CommandLineTag {
+    typ: u32,
+    size: u32,
+    string: u8,
+}
+
+impl CommandLineTag {
+    pub fn command_line(&self) -> &str {
+        use core::{mem,str,slice};
+        unsafe {
+            let strlen = self.size as usize - mem::size_of::<CommandLineTag>();
+            str::from_utf8_unchecked(
+                slice::from_raw_parts((&self.string) as *const u8, strlen))
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub use elf_sections::{ElfSectionsTag, ElfSection, ElfSectionIter, ElfSectionTyp
 pub use elf_sections::{ELF_SECTION_WRITABLE, ELF_SECTION_ALLOCATED, ELF_SECTION_EXECUTABLE};
 pub use memory_map::{MemoryMapTag, MemoryArea, MemoryAreaIter};
 pub use module::{ModuleTag, ModuleIter};
+pub use command_line::CommandLineTag;
 
 #[macro_use]
 extern crate bitflags;
@@ -15,6 +16,7 @@ mod boot_loader_name;
 mod elf_sections;
 mod memory_map;
 mod module;
+mod command_line;
 
 pub unsafe fn load(address: usize) -> &'static BootInformation {
     let multiboot = &*(address as *const BootInformation);
@@ -52,6 +54,10 @@ impl BootInformation {
 
     pub fn boot_loader_name_tag(&self) -> Option<&'static BootLoaderNameTag> {
         self.get_tag(2).map(|tag| unsafe{&*(tag as *const Tag as *const BootLoaderNameTag)})
+    }
+
+    pub fn command_line_tag(&self) -> Option<&'static CommandLineTag> {
+        self.get_tag(1).map(|tag| unsafe{&*(tag as *const Tag as *const CommandLineTag)})
     }
 
     fn has_valid_end_tag(&self) -> bool {


### PR DESCRIPTION
This is just a copy of the boot loader name tag code, but for the command line tag (type = 1).