### PR TITLE
Add support for ELF32 format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ description = "An experimental Multiboot 2 crate for ELF-64 kernels."
 [dependencies.bitflags]
 version = "0.4.0"
 features = ["no_std"]
+
+[features]
+elf32 = []

--- a/src/elf_sections.rs
+++ b/src/elf_sections.rs
@@ -149,7 +149,7 @@ pub enum ElfSectionType {
 type ElfSectionFlagsType = u32;
 
 #[cfg(not(feature = "elf32"))]
-type ElfSectionFlagsType = u32;
+type ElfSectionFlagsType = u64;
 
 bitflags! {
     flags ElfSectionFlags: ElfSectionFlagsType {

--- a/src/elf_sections.rs
+++ b/src/elf_sections.rs
@@ -77,6 +77,23 @@ impl Iterator for ElfSectionIter {
     }
 }
 
+#[cfg(feature = "elf32")]
+#[derive(Debug)]
+#[repr(C)]
+pub struct ElfSection {
+    name_index: u32,
+    typ: u32,
+    pub flags: u32,
+    pub addr: u32,
+    offset: u32,
+    pub size: u32,
+    link: u32,
+    info: u32,
+    addralign: u32,
+    entry_size: u32,
+}
+
+#[cfg(not(feature = "elf32"))]
 #[derive(Debug)]
 #[repr(C)]
 pub struct ElfSection {
@@ -128,8 +145,14 @@ pub enum ElfSectionType {
     // plus processor-specific use from 0x70000000 to 0x7FFFFFFF
 }
 
+#[cfg(feature = "elf32")]
+type ElfSectionFlagsType = u32;
+
+#[cfg(not(feature = "elf32"))]
+type ElfSectionFlagsType = u32;
+
 bitflags! {
-    flags ElfSectionFlags: u64 {
+    flags ElfSectionFlags: ElfSectionFlagsType {
         const ELF_SECTION_WRITABLE = 0x1,
         const ELF_SECTION_ALLOCATED = 0x2,
         const ELF_SECTION_EXECUTABLE = 0x4,


### PR DESCRIPTION
I'm following your guide, but instead I'm making a 32-bit kernel which uses ELF32 files. I added a new feature, `elf32`, which tweaks `ElfSections` to match this standard.

(I know, the project is called multiboot-elf64. But this doesn't hurt and helps a lot :-) )