### PR TITLE
Change pub fields into functions.

### DIFF
--- a/src/elf_sections.rs
+++ b/src/elf_sections.rs
@@ -4,7 +4,7 @@
 pub struct ElfSectionsTag {
     typ: u32,
     size: u32,
-    pub number_of_sections: u32,
+    number_of_sections: u32,
     entry_size: u32,
     shndx: u32, // string table
     first_section: ElfSection,
@@ -83,10 +83,10 @@ impl Iterator for ElfSectionIter {
 pub struct ElfSection {
     name_index: u32,
     typ: u32,
-    pub flags: u32,
-    pub addr: u32,
+    flags: u32,
+    addr: u32,
     offset: u32,
-    pub size: u32,
+    size: u32,
     link: u32,
     info: u32,
     addralign: u32,
@@ -99,10 +99,10 @@ pub struct ElfSection {
 pub struct ElfSection {
     name_index: u32,
     typ: u32,
-    pub flags: u64,
-    pub addr: u64,
+    flags: u64,
+    addr: u64,
     offset: u64,
-    pub size: u64,
+    size: u64,
     link: u32,
     info: u32,
     addralign: u64,
@@ -110,12 +110,40 @@ pub struct ElfSection {
 }
 
 impl ElfSection {
+    pub fn section_type(&self) -> ElfSectionType {
+        match self.typ {
+            0 => ElfSectionType::Unused,
+            1 => ElfSectionType::ProgramSection,
+            2 => ElfSectionType::LinkerSymbolTable,
+            3 => ElfSectionType::StringTable,
+            4 => ElfSectionType::RelaRelocation,
+            5 => ElfSectionType::SymbolHashTable,
+            6 => ElfSectionType::DynamicLinkingTable,
+            7 => ElfSectionType::Note,
+            8 => ElfSectionType::Uninitialized,
+            9 => ElfSectionType::RelRelocation,
+            10 => ElfSectionType::Reserved,
+            11 => ElfSectionType::DynamicLoaderSymbolTable,
+            0x6000_0000...0x6FFF_FFFF => ElfSectionType::EnvironmentSpecific,
+            0x7000_0000...0x7FFF_FFFF => ElfSectionType::ProcessorSpecific,
+            _ => panic!(),
+        }
+    }
+
+    pub fn section_type_raw(&self) -> u32 {
+        self.typ
+    }
+
     pub fn start_address(&self) -> usize {
         self.addr as usize
     }
 
     pub fn end_address(&self) -> usize {
         (self.addr + self.size) as usize
+    }
+
+    pub fn size(&self) -> usize {
+        self.size as usize
     }
 
     pub fn flags(&self) -> ElfSectionFlags {
@@ -127,6 +155,7 @@ impl ElfSection {
     }
 }
 
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
 #[repr(u32)]
 pub enum ElfSectionType {
     Unused = 0,
@@ -141,8 +170,8 @@ pub enum ElfSectionType {
     RelRelocation = 9,
     Reserved = 10,
     DynamicLoaderSymbolTable = 11,
-    // plus environment-specific use from 0x60000000 to 0x6FFFFFFF
-    // plus processor-specific use from 0x70000000 to 0x7FFFFFFF
+    EnvironmentSpecific = 0x6000_0000,
+    ProcessorSpecific = 0x7000_0000,
 }
 
 #[cfg(feature = "elf32")]

--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -24,10 +24,24 @@ impl MemoryMapTag {
 #[derive(Debug)]
 #[repr(C)]
 pub struct MemoryArea {
-    pub base_addr: u64,
-    pub length: u64,
+    base_addr: u64,
+    length: u64,
     typ: u32,
     _reserved: u32,
+}
+
+impl MemoryArea {
+    pub fn start_address(&self) -> usize {
+        self.base_addr as usize
+    }
+
+    pub fn end_address(&self) -> usize {
+        (self.base_addr + self.length) as usize
+    }
+
+    pub fn size(&self) -> usize {
+        self.length as usize
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/module.rs
+++ b/src/module.rs
@@ -32,8 +32,12 @@ impl ModuleTag {
     }
 }
 
+pub fn module_iter(iter: TagIter) -> ModuleIter {
+    ModuleIter { iter: iter }
+}
+
 pub struct ModuleIter {
-    pub iter: TagIter,
+    iter: TagIter,
 }
 
 impl Iterator for ModuleIter {


### PR DESCRIPTION
This hides the implementation enough to allow supporting higher memory kernels.