### PR TITLE
Make MemoryMapIter be Send

### DIFF
--- a/src/memory_map.rs
+++ b/src/memory_map.rs
@@ -13,9 +13,8 @@ impl MemoryMapTag {
         let self_ptr = self as *const MemoryMapTag;
         let start_area = (&self.first_area) as *const MemoryArea;
         MemoryAreaIter {
-            current_area: start_area,
-            last_area: (self_ptr as u64 + (self.size - self.entry_size) as u64)
-                as *const MemoryArea,
+            current_area: start_area as u64,
+            last_area: (self_ptr as u64 + (self.size - self.entry_size) as u64),
             entry_size: self.entry_size,
         }
     }
@@ -46,8 +45,8 @@ impl MemoryArea {
 
 #[derive(Clone, Debug)]
 pub struct MemoryAreaIter {
-    current_area: *const MemoryArea,
-    last_area: *const MemoryArea,
+    current_area: u64,
+    last_area: u64,
     entry_size: u32,
 }
 
@@ -57,9 +56,8 @@ impl Iterator for MemoryAreaIter {
         if self.current_area > self.last_area {
             None
         } else {
-            let area = unsafe{&*self.current_area};
-            self.current_area = ((self.current_area as u64) + self.entry_size as u64)
-                as *const MemoryArea;
+            let area = unsafe{&*(self.current_area as *const MemoryArea)};
+            self.current_area = self.current_area + (self.entry_size as u64);
             if area.typ == 1 {
                 Some(area)
             } else {self.next()}


### PR DESCRIPTION
Hey thanks for the great OS series!

MemoryMapIter is used in the AreaFrameAllocator, which I want to put inside a Mutex and make global. I want to access it in syscalls. To be put inside a Mutex, it has to be `Send`.