### PR TITLE
Update to the 1.0.0 version of bitflags.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,5 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>", "Calvin Lee <cyrus296@gmail.c
 license = "MIT/Apache-2.0"
 description = "An experimental Multiboot 2 crate for ELF-64/32 kernels."
 
-[dependencies.bitflags]
-version = "0.4.0"
-features = ["no_std"]
+[dependencies]
+bitflags = "1.0.0"

--- a/src/elf_sections.rs
+++ b/src/elf_sections.rs
@@ -173,7 +173,7 @@ impl ElfSection {
     }
 
     pub fn is_allocated(&self) -> bool {
-        self.flags().contains(ELF_SECTION_ALLOCATED)
+        self.flags().contains(ElfSectionFlags::ALLOCATED)
     }
 
     fn get(&self) -> &ElfSectionInner {
@@ -269,10 +269,10 @@ pub enum ElfSectionType {
 }
 
 bitflags! {
-    flags ElfSectionFlags: u32 {
-        const ELF_SECTION_WRITABLE = 0x1,
-        const ELF_SECTION_ALLOCATED = 0x2,
-        const ELF_SECTION_EXECUTABLE = 0x4,
+    pub struct ElfSectionFlags: u32 {
+        const WRITABLE = 0x1;
+        const ALLOCATED = 0x2;
+        const EXECUTABLE = 0x4;
         // plus environment-specific use at 0x0F000000
         // plus processor-specific use at 0xF0000000
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ use core::fmt;
 use header::{Tag, TagIter};
 pub use boot_loader_name::BootLoaderNameTag;
 pub use elf_sections::{ElfSectionsTag, ElfSection, ElfSectionIter, ElfSectionType, ElfSectionFlags};
-pub use elf_sections::{ELF_SECTION_WRITABLE, ELF_SECTION_ALLOCATED, ELF_SECTION_EXECUTABLE};
 pub use memory_map::{MemoryMapTag, MemoryArea, MemoryAreaIter};
 pub use module::{ModuleTag, ModuleIter};
 pub use command_line::CommandLineTag;
@@ -143,8 +142,7 @@ impl fmt::Debug for BootInformation {
 #[cfg(test)]
 mod tests {
     use super::load;
-    use super::{ElfSectionFlags, ELF_SECTION_EXECUTABLE, ELF_SECTION_ALLOCATED, ELF_SECTION_WRITABLE};
-    use super::ElfSectionType;
+    use super::{ElfSectionFlags, ElfSectionType};
 
     #[test]
     fn no_tags() {
@@ -513,35 +511,35 @@ mod tests {
         assert_eq!(0xFFFF_8000_0010_0000, s1.start_address());
         assert_eq!(0xFFFF_8000_0010_3000, s1.end_address());
         assert_eq!(0x0000_0000_0000_3000, s1.size());
-        assert_eq!(ELF_SECTION_ALLOCATED, s1.flags());
+        assert_eq!(ElfSectionFlags::ALLOCATED, s1.flags());
         assert_eq!(ElfSectionType::ProgramSection, s1.section_type());
         let s2 = s.next().unwrap();
         assert_eq!(".text", s2.name());
         assert_eq!(0xFFFF_8000_0010_3000, s2.start_address());
         assert_eq!(0xFFFF_8000_0010_C000, s2.end_address());
         assert_eq!(0x0000_0000_0000_9000, s2.size());
-        assert_eq!(ELF_SECTION_EXECUTABLE | ELF_SECTION_ALLOCATED, s2.flags());
+        assert_eq!(ElfSectionFlags::EXECUTABLE | ElfSectionFlags::ALLOCATED, s2.flags());
         assert_eq!(ElfSectionType::ProgramSection, s2.section_type());
         let s3 = s.next().unwrap();
         assert_eq!(".data", s3.name());
         assert_eq!(0xFFFF_8000_0010_C000, s3.start_address());
         assert_eq!(0xFFFF_8000_0010_E000, s3.end_address());
         assert_eq!(0x0000_0000_0000_2000, s3.size());
-        assert_eq!(ELF_SECTION_ALLOCATED | ELF_SECTION_WRITABLE, s3.flags());
+        assert_eq!(ElfSectionFlags::ALLOCATED | ElfSectionFlags::WRITABLE, s3.flags());
         assert_eq!(ElfSectionType::ProgramSection, s3.section_type());
         let s4 = s.next().unwrap();
         assert_eq!(".bss", s4.name());
         assert_eq!(0xFFFF_8000_0010_E000, s4.start_address());
         assert_eq!(0xFFFF_8000_0011_3000, s4.end_address());
         assert_eq!(0x0000_0000_0000_5000, s4.size());
-        assert_eq!(ELF_SECTION_ALLOCATED | ELF_SECTION_WRITABLE, s4.flags());
+        assert_eq!(ElfSectionFlags::ALLOCATED | ElfSectionFlags::WRITABLE, s4.flags());
         assert_eq!(ElfSectionType::Uninitialized, s4.section_type());
         let s5 = s.next().unwrap();
         assert_eq!(".data.rel.ro", s5.name());
         assert_eq!(0xFFFF_8000_0011_3000, s5.start_address());
         assert_eq!(0xFFFF_8000_0011_3000, s5.end_address());
         assert_eq!(0x0000_0000_0000_0000, s5.size());
-        assert_eq!(ELF_SECTION_ALLOCATED | ELF_SECTION_WRITABLE, s5.flags());
+        assert_eq!(ElfSectionFlags::ALLOCATED | ElfSectionFlags::WRITABLE, s5.flags());
         assert_eq!(ElfSectionType::ProgramSection, s5.section_type());
         let s6 = s.next().unwrap();
         assert_eq!(".symtab", s6.name());


### PR DESCRIPTION
Note, this is technically a breaking change but I'd say it's a good one given that it results in using a stable version of bitflags.