### PR TITLE
Resolve tyvar_behind_raw_pointer warning

### DIFF
--- a/src/elf_sections.rs
+++ b/src/elf_sections.rs
@@ -8,7 +8,7 @@ pub struct ElfSectionsTag {
 pub fn elf_sections_tag(tag: &Tag) -> ElfSectionsTag {
     assert_eq!(9, tag.typ);
     let es = ElfSectionsTag {
-        inner: unsafe { (tag as *const _).offset(1) } as *const _,
+        inner: unsafe { (tag as *const Tag).offset(1) } as *const ElfSectionsTagInner,
     };
     assert!((es.get().entry_size * es.get().shndx) <= tag.size);
     es


### PR DESCRIPTION
Fix the following warning before it becomes a hard error:

```
warning: the type of this value must be known in this context
  --> src/elf_sections.rs:11:43
   |
11 |         inner: unsafe { (tag as *const _).offset(1) } as *const _,
   |                                           ^^^^^^
   |
   = note: #[warn(tyvar_behind_raw_pointer)] on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #46906 <https://github.com/rust-lang/rust/issues/46906>
```